### PR TITLE
Fix application file permission in python template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM python:3.4-alpine
+FROM python:3.7-alpine
 ADD . /code
 WORKDIR /code
+RUN chmod 644 /code/app.py
 RUN pip install flask
 CMD ["python", "app.py"]
 EXPOSE 5000


### PR DESCRIPTION
Fix for `OSError: [Errno 8] Exec format error` when running python template on Windows. Fix is to set the file permission on the application to 644 in the docker build. Also updating the python alpine base image, as the current one is deprecated and gives warnings in the docker build.

See
https://stackoverflow.com/questions/55315103/oserror-errno-8-exec-format-error-when-trying-to-run-simple-flask-app-in-a/55359108#55359108